### PR TITLE
fix: add path validation in VirtualAdapter.php

### DIFF
--- a/app/Services/VFS/VirtualAdapter.php
+++ b/app/Services/VFS/VirtualAdapter.php
@@ -26,8 +26,6 @@ class VirtualAdapter implements IFileSystem
         $remaining = $parts[1] ?? '';
 
         if (isset($this->mounts[$alias])) {
-            // Canonicalize the remaining path before handing it to the mounted
-            // adapter so '../' traversal sequences can never escape the mount.
             $remaining = PathPolicy::normalizeRelative($remaining);
             return [$this->mounts[$alias], $remaining];
         }

--- a/app/Services/VFS/VirtualAdapter.php
+++ b/app/Services/VFS/VirtualAdapter.php
@@ -26,6 +26,9 @@ class VirtualAdapter implements IFileSystem
         $remaining = $parts[1] ?? '';
 
         if (isset($this->mounts[$alias])) {
+            // Canonicalize the remaining path before handing it to the mounted
+            // adapter so '../' traversal sequences can never escape the mount.
+            $remaining = PathPolicy::normalizeRelative($remaining);
             return [$this->mounts[$alias], $remaining];
         }
 

--- a/tests/unit/VirtualVfsTest.php
+++ b/tests/unit/VirtualVfsTest.php
@@ -8,6 +8,16 @@ use App\Services\VFS\LocalAdapter;
 
 class VirtualVfsTest extends CIUnitTestCase
 {
+    private function assertTraversalBlocked(callable $operation): void
+    {
+        try {
+            $operation();
+            $this->fail('Expected mounted path traversal to be rejected.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString('traversal', strtolower($exception->getMessage()));
+        }
+    }
+
     private function deleteTree(string $path): void
     {
         if (!file_exists($path)) {
@@ -87,5 +97,45 @@ class VirtualVfsTest extends CIUnitTestCase
 
         $this->deleteTree($sourceRoot);
         $this->deleteTree($targetRoot);
+    }
+
+    public function testMountedPathTraversalIsRejectedBeforeAnyOperationReachesTheAdapter(): void
+    {
+        $root = sys_get_temp_dir() . '/test_vfs_traversal_' . uniqid('', true);
+        mkdir($root, 0755, true);
+        file_put_contents($root . '/inside.txt', 'inside');
+
+        $vfs = new VirtualAdapter();
+        $vfs->mount('Test', new LocalAdapter($root));
+
+        $operations = [
+            static fn() => $vfs->listDirectory('Test/../outside'),
+            static fn() => $vfs->readFile('Test/../outside.txt'),
+            static fn() => $vfs->openReadStream('Test\\..\\outside.txt'),
+            static fn() => $vfs->writeFile('Test/../outside.txt', 'blocked'),
+            static fn() => $vfs->delete('Test/../outside.txt'),
+            static fn() => $vfs->createDirectory('Test/../outside'),
+            static fn() => $vfs->move('Test/../outside.txt', 'Test/inside.txt'),
+            static fn() => $vfs->move('Test/inside.txt', 'Test/../outside.txt'),
+            static fn() => $vfs->copy('Test/../outside.txt', 'Test/copy.txt'),
+            static fn() => $vfs->copy('Test/inside.txt', 'Test/../copy.txt'),
+            static fn() => $vfs->getMetadata('Test/../outside.txt'),
+            static fn() => $vfs->chmod('Test/../outside.txt', 0644),
+            static fn() => $vfs->chown('Test/../outside.txt', 'user', 'group'),
+            static fn() => $vfs->getDirectorySize('Test/../outside'),
+            static fn() => $vfs->archive(['Test/../outside.txt'], 'Test/archive.zip'),
+            static fn() => $vfs->extract('Test/archive.zip', 'Test/../outside'),
+            static fn() => $vfs->resolvePath('Test\\..\\outside.txt'),
+        ];
+
+        foreach ($operations as $operation) {
+            $this->assertTraversalBlocked($operation);
+        }
+
+        $this->assertFileDoesNotExist(dirname($root) . '/outside.txt');
+        $this->assertFileDoesNotExist($root . '/outside.txt');
+        $this->assertFileExists($root . '/inside.txt');
+
+        $this->deleteTree($root);
     }
 }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `app/Services/VFS/VirtualAdapter.php`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `app/Services/VFS/VirtualAdapter.php:60` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-22 |
| **Chain Complexity** | 2-step |

**Description**: The VirtualAdapter.php delete() method and TrashService.php operations process file paths without proper canonicalization. The resolveMount() method splits paths and passes them to underlying adapters without validating path traversal sequences like '../' that could escape the intended directory boundary.

## Evidence

**Exploitation scenario**: An authenticated attacker sends a DELETE request with path 'mountname/../../../etc/passwd'.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `app/Services/VFS/VirtualAdapter.php`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

## Security Invariant
> **Property**: File operations never resolve paths outside the declared root directory

<details>
<summary>Regression test</summary>

```php
<?php

namespace Tests\Unit\Services\VFS;

use PHPUnit\Framework\TestCase;
use App\Services\VFS\VirtualAdapter;

class VirtualAdapterPathTraversalTest extends TestCase
{
    /**
     * Invariant: resolveMount never resolves paths outside declared root directory
     * 
     * @dataProvider pathTraversalPayloads
     */
    public function testResolveMountRejectsPathTraversal(string $payload): void
    {
        $adapter = new VirtualAdapter([
            'storage' => '/var/www/storage',
        ]);

        // resolveMount is private; test via public delete() or reflection
        // The vulnerability: '../' sequences bypass validation and escape root
        
        $reflection = new \ReflectionClass($adapter);
        $method = $reflection->getMethod('resolveMount');
        $method->setAccessible(true);

        [$mount, $remaining] = $method->invoke($adapter, $payload);

        // If mount is null, path wasn't resolved to a valid mount (rejected/fallback)
        // If mount is set, remaining path must not contain traversal sequences
        if ($mount !== null) {
            $this->assertStringNotContainsString('..', $remaining, 'Path traversal detected in resolved path');
            $this->assertStringNotContainsString('\\', $remaining, 'Backslash path traversal detected');
        }
    }

    public static function pathTraversalPayloads(): array
    {
        return [
            'classic traversal' => ['../../../etc/passwd'],
            'double dot slash encoding' => ['....//....//etc/passwd'],
            'url encoded traversal' => ['%2e%2e%2f%2e%2e%2f%2e%2e%2fetc/passwd'],
            'boundary valid path' => ['storage/../file.txt'],
            'valid clean path' => ['storage/documents/file.txt'],
        ];
    }
}
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
